### PR TITLE
The issue is indeed with using too much memory. 

### DIFF
--- a/infer_batch.py
+++ b/infer_batch.py
@@ -1,16 +1,17 @@
 import os
 import csv
 import argparse
+import tensorflow as tf
+import keras.backend as K
 
 from glob import glob
 
 from lib.io import openpose_from_file, read_segmentation, write_mesh
 from model.octopus import Octopus
 
-import tensorflow as tf
 
 def main(weights, num, batch_file, opt_pose_steps, opt_shape_steps):
-    tf.keras.backend.set_session(tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))))
+    K.set_session(tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))))
 
     model = Octopus(num=num)
 

--- a/infer_batch.py
+++ b/infer_batch.py
@@ -7,8 +7,11 @@ from glob import glob
 from lib.io import openpose_from_file, read_segmentation, write_mesh
 from model.octopus import Octopus
 
+import tensorflow as tf
 
 def main(weights, num, batch_file, opt_pose_steps, opt_shape_steps):
+    tf.keras.backend.set_session(tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))))
+
     model = Octopus(num=num)
 
     with open(batch_file, 'rb') as f:

--- a/infer_single.py
+++ b/infer_single.py
@@ -6,6 +6,7 @@ from glob import glob
 from lib.io import openpose_from_file, read_segmentation, write_mesh
 from model.octopus import Octopus
 
+import tensorflow as tf
 
 def main(weights, name, segm_dir, pose_dir, out_dir, opt_pose_steps, opt_shape_steps):
     segm_files = sorted(glob(os.path.join(segm_dir, '*.png')))
@@ -13,6 +14,8 @@ def main(weights, name, segm_dir, pose_dir, out_dir, opt_pose_steps, opt_shape_s
 
     if len(segm_files) != len(pose_files) or len(segm_files) == len(pose_files) == 0:
         exit('Inconsistent input.')
+
+    tf.keras.backend.set_session(tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))))
 
     model = Octopus(num=len(segm_files))
     model.load(weights)

--- a/infer_single.py
+++ b/infer_single.py
@@ -1,12 +1,13 @@
 import os
 import argparse
+import tensorflow as tf
+import keras.backend as K
 
 from glob import glob
 
 from lib.io import openpose_from_file, read_segmentation, write_mesh
 from model.octopus import Octopus
 
-import tensorflow as tf
 
 def main(weights, name, segm_dir, pose_dir, out_dir, opt_pose_steps, opt_shape_steps):
     segm_files = sorted(glob(os.path.join(segm_dir, '*.png')))
@@ -15,7 +16,7 @@ def main(weights, name, segm_dir, pose_dir, out_dir, opt_pose_steps, opt_shape_s
     if len(segm_files) != len(pose_files) or len(segm_files) == len(pose_files) == 0:
         exit('Inconsistent input.')
 
-    tf.keras.backend.set_session(tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))))
+    K.set_session(tf.Session(config=tf.ConfigProto(gpu_options=tf.GPUOptions(allow_growth=True))))
 
     model = Octopus(num=len(segm_files))
     model.load(weights)


### PR DESCRIPTION
Octopus does not use allow_growth, so tensorflow grabs all the GPU memory, which leaves DIRT unable to perform its own small allocations.

https://github.com/thmoa/octopus/issues/4